### PR TITLE
Move the gem install generator into the Dockerfile 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ RUN mkdir -p $CACHE_PATH
 RUN mkdir -p $WORKING_PATH
 
 # Create shared directory - required by docker
-RUN mkdir -p $APP_WORKDIR/shared
+RUN mkdir -p $APP_WORKDIR/shared/state
 
 WORKDIR $APP_WORKDIR
 
@@ -55,11 +55,15 @@ WORKDIR $APP_WORKDIR
 RUN mkdir app
 COPY . $APP_WORKDIR
 
+# Install the gem
 COPY repo_builder.sh /bin/
 RUN chmod +x /bin/repo_builder.sh
 RUN /bin/repo_builder.sh
 
 RUN if [ "$RAILS_ENV" = "production" ]; then bundle install --without development test; else bundle install; fi
+
+# Run the gem installer
+RUN if [ -n "${GEM_KEY+set}" ]; then bundle exec rails g $GEM_KEY:install ; fi
 
 COPY docker-entrypoint.sh /bin/
 RUN chmod +x /bin/docker-entrypoint.sh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     devise-guests (0.6.1)
       devise
     diff-lcs (1.3)
-    dog_biscuits (0.5.5)
+    dog_biscuits (0.5.6)
       hyrax (>= 2, < 3)
     dropbox_api (0.1.16)
       faraday (>= 0.8, <= 0.15.4)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ volumes:
   redis:
   uploads:
   derivatives:
+  state:
 
 networks:
   internal:
@@ -95,6 +96,7 @@ services:
     volumes:
       - uploads:${UPLOADS_PATH}
       - derivatives:${DERIVATIVES_PATH}
+      - state:$APP_WORKDIR/shared/state
     tmpfs:
     - /${PIDS_PATH}
     networks:

--- a/docker-entrypoint-web.sh
+++ b/docker-entrypoint-web.sh
@@ -3,52 +3,53 @@
 # Run the base entrypoint
 bash /bin/docker-entrypoint.sh
 
+# Run the initialization tasks on first run
+
 FLAG=""
-if [ ! -f $APP_WORKDIR/shared/.gem_installed ]; then
+# On first deploy set the --initial flag
+# This is global and persists across images
+#   ie. we don't want to re-initialize on a new image
+if [ ! -f $APP_WORKDIR/shared/state/.initialized ]; then
     echo "Setting the initial flag"
-    FLAG=" --initial"
-    touch $APP_WORKDIR/shared/.gem_installed
+    FLAG="initialize"
+    touch $APP_WORKDIR/shared/state/.initialized
 fi
 
 # Solr / Fedora need to be running for initial setup only
-if [ "$FLAG" = "--initial" ]; then 
-    # wait for Solr and Fedora to come up
-    sleep 15s
-    
-    # check that Solr is running
-    SOLR=$(curl --silent --connect-timeout 45 "http://${SOLR_HOST:-solr}:${SOLR_PORT:-8983}/solr/" | grep "Apache SOLR")
-    if [ -n "$SOLR" ] ; then
-        echo "Solr is running..."
-    else
-        echo "ERROR: Solr is not running"
-        # exit 1
-    fi
-    
-    # check that Fedora is running
-    FEDORA=$(curl --silent --connect-timeout 45 "http://${FEDORA_HOST:-fcrepo}:${FEDORA_PORT:-8080}/fcrepo/" | grep "Fedora Commons Repository")
-    if [ -n "$FEDORA" ] ; then
-        echo "Fedora is running..."
-    else
-        echo "ERROR: Fedora is not running"
-        # exit 1
-    fi
-fi
+if [ "$FLAG" = "initialize" ]; then 
+  # wait for Solr and Fedora to come up
+  sleep 15s
+  
+  # check that Solr is running
+  SOLR=$(curl --silent --connect-timeout 45 "http://${SOLR_HOST:-solr}:${SOLR_PORT:-8983}/solr/" | grep "Apache SOLR")
+  if [ -n "$SOLR" ] ; then
+      echo "Solr is running..."
+  else
+      echo "ERROR: Solr is not running"
+      # exit 1
+  fi
+  
+  # check that Fedora is running
+  FEDORA=$(curl --silent --connect-timeout 45 "http://${FEDORA_HOST:-fcrepo}:${FEDORA_PORT:-8080}/fcrepo/" | grep "Fedora Commons Repository")
+  if [ -n "$FEDORA" ] ; then
+      echo "Fedora is running..."
+  else
+      echo "ERROR: Fedora is not running"
+      # exit 1
+  fi
 
-# With the --initial flag, the install generator runs the setup rake tasks
-if [ -n "${GEM_KEY+set}" ]; then
-  echo "Running the installer"
-  bundle exec rails g $GEM_KEY:install $FLAG
-# If the GEM_KEY isn't set on the initial run; run the setup tasks
-elif [ ! -n "${GEM_KEY+set}" ] && [ "$FLAG" == "--initial" ] ; then
-  echo "Running the setup tasks"
-  bundle exec rake assets:clean assets:precompile
-  bundle exec rake hyrax:default_admin_set:create
-  bundle exec rake hyrax:workflow:load
-  bundle exec rake hyrax:default_collection_types:create
-else
-  echo "Check for new assets"
-  bundle exec rake assets:clean assets:precompile
-fi 
+  if [ -n "${GEM_KEY+set}" ]; then
+    echo "Running the installer"
+    bundle exec rails g $GEM_KEY:initialize
+  # If the GEM_KEY isn't set on the initial run; run the setup tasks
+  elif [ ! -n "${GEM_KEY+set}" ] && [ "$FLAG" == "--initial" ] ; then
+    echo "Running the initialization tasks"
+    bundle exec rake assets:clean assets:precompile
+    bundle exec rake hyrax:default_admin_set:create
+    bundle exec rake hyrax:workflow:load
+    bundle exec rake hyrax:default_collection_types:create
+  fi
+fi
 
 echo "--------- Starting Hyrax in $RAILS_ENV mode ---------"
 bundle exec rails server -p $RAILS_PORT -b '0.0.0.0' --pid $PIDS_PATH/$APPLICATION_KEY.pid

--- a/docker-entrypoint-worker.sh
+++ b/docker-entrypoint-worker.sh
@@ -3,11 +3,5 @@
 # Run the base entrypoint
 bash /bin/docker-entrypoint.sh
 
-# Run the installer
-if [ -n "${GEM_KEY+set}" ]; then
-  echo "Running the installer"
-  bundle exec rails g $GEM_KEY:install
-fi 
-
 echo "--------- Starting Sidekiq in $RAILS_ENV mode ---------"
 bundle exec sidekiq

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,11 +5,10 @@ echo "Running the base entrypoint"
 echo "Creating pids folders"
 mkdir -p $PIDS_PATH
 
-if [ "$RAILS_ENV" = "production" ]; then
+if [ "$RAILS_ENV" EQ "production" ]; then
+    echo 'Not doing it'
     # Verify all the production gems are installed
     bundle check
-    # Remove any unused gems
-    bundle clean --force
 else
     # install any missing development gems (as we can tweak the development container without rebuilding it)
     bundle check || bundle install --without production


### PR DESCRIPTION
Existing code had to run the gem install generator in the entrypoint, which meant running it every time the container is 'up' and also running it twice on the web and workers. 

Some changes to the underlying gem means that we can now run it in the Dockerfile and then *not* have to run it everytime we bring the container up and down.